### PR TITLE
Fixing request-bodies according to the latest version

### DIFF
--- a/src/main/groovy/uk/gov/gradle/plugins/GatlingPlugin.groovy
+++ b/src/main/groovy/uk/gov/gradle/plugins/GatlingPlugin.groovy
@@ -28,7 +28,7 @@ class GatlingPlugin implements Plugin<Project> {
 				dependsOn:'build') << {
 			project.gatling.verifySettings()
 			final def sourceSet = project.sourceSets.test
-			final def gatlingRequestBodiesDirectory = firstPath(sourceSet.resources.srcDirs) + "/request-bodies"
+			final def gatlingRequestBodiesDirectory = firstPath(sourceSet.resources.srcDirs) + "/bodies"
 			final def gatlingClasspath = sourceSet.output + sourceSet.runtimeClasspath
 			final def scenarios = project.gatling._scenarios ?: getGatlingScenarios(sourceSet)
 			logger.lifecycle "Executing gatling scenarios: $scenarios"
@@ -84,4 +84,3 @@ class GatlingPlugin implements Plugin<Project> {
 		new File(gatlingReportsDirectory).eachDirMatch(~/.*-\d+/, c)
 	}
 }
-


### PR DESCRIPTION
Fixing request-bodies according to the latest version

Documentation for migrating from version 2.0 to 2.1 http://gatling.io/docs/2.1.2/project/migration_guides/2.0-to-2.1.html#to-2-1 talks about this change.