### PR TITLE
Fixes for issue #15

### DIFF
--- a/src/main/groovy/uk/gov/gradle/plugins/GatlingPlugin.groovy
+++ b/src/main/groovy/uk/gov/gradle/plugins/GatlingPlugin.groovy
@@ -4,7 +4,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 class GatlingPlugin implements Plugin<Project> {
-	final String GATLING_VERSION = '2.1.3'
+	final String GATLING_VERSION = '2.1.6'
 
 	private String gatlingReportsDirectory
 	private Project project
@@ -20,6 +20,12 @@ class GatlingPlugin implements Plugin<Project> {
 		gatlingReportsDirectory = "$project.buildDir.absolutePath/gatling-reports"
 		project.task('gatlingTest',
 				dependsOn:'build') << {
+			def targetTestClassesFolder = new File (System.getProperty("user.dir"), 'target/test-classes')
+			def fakeFolderHack = !targetTestClassesFolder.exists()
+			if (fakeFolderHack) {
+				//needed since gatling fails if missing
+				targetTestClasses.mkdirs()
+			}
 			project.gatling.verifySettings()
 			final def sourceSet = project.sourceSets.test
 			final def gatlingRequestBodiesDirectory = firstPath(sourceSet.resources.srcDirs) + "/bodies"
@@ -41,6 +47,11 @@ class GatlingPlugin implements Plugin<Project> {
 					systemProperties(project.gatling.systemProperties ?: [:])
 				}
 			}
+			if (fakeFolderHack) {
+				//removes empty directory
+				targetTestClasses.delete()
+			}
+
 			logger.lifecycle "Gatling scenarios completed."
 		}
 		project.task('openGatlingReport') << {

--- a/src/main/groovy/uk/gov/gradle/plugins/GatlingPlugin.groovy
+++ b/src/main/groovy/uk/gov/gradle/plugins/GatlingPlugin.groovy
@@ -17,12 +17,6 @@ class GatlingPlugin implements Plugin<Project> {
 			testCompile "io.gatling.highcharts:gatling-charts-highcharts:${GATLING_VERSION}",
 					'com.nimbusds:nimbus-jose-jwt:2.22.1'
 		}
-		project.repositories {
-			maven {
-				url 'http://repository.excilys.com/content/groups/public'
-				url 'https://oss.sonatype.org/content/repositories/snapshots'
-			}
-		}
 		gatlingReportsDirectory = "$project.buildDir.absolutePath/gatling-reports"
 		project.task('gatlingTest',
 				dependsOn:'build') << {

--- a/src/main/groovy/uk/gov/gradle/plugins/GatlingPlugin.groovy
+++ b/src/main/groovy/uk/gov/gradle/plugins/GatlingPlugin.groovy
@@ -24,7 +24,7 @@ class GatlingPlugin implements Plugin<Project> {
 			def fakeFolderHack = !targetTestClassesFolder.exists()
 			if (fakeFolderHack) {
 				//needed since gatling fails if missing
-				targetTestClasses.mkdirs()
+				targetTestClassesFolder.mkdirs()
 			}
 			project.gatling.verifySettings()
 			final def sourceSet = project.sourceSets.test
@@ -49,7 +49,7 @@ class GatlingPlugin implements Plugin<Project> {
 			}
 			if (fakeFolderHack) {
 				//removes empty directory
-				targetTestClasses.delete()
+				targetTestClassesFolder.delete()
 			}
 
 			logger.lifecycle "Gatling scenarios completed."


### PR DESCRIPTION
The symptoms of issue #15 were mostly discussed even on issue #17.
Did the following:
- removed unnecessary repositories from plugin (_mavenCentral()_ should be declared by client code)
- introduced a hack that creates and removes the _target/test-classes_ folder, as it seems that gatling lib _wants_ it
- bump up gatling version
