### PR TITLE
BAU: fix gradle compatibility issue

### DIFF
--- a/src/main/groovy/uk/gov/gradle/plugins/GatlingPlugin.groovy
+++ b/src/main/groovy/uk/gov/gradle/plugins/GatlingPlugin.groovy
@@ -23,7 +23,7 @@ class GatlingPlugin implements Plugin<Project> {
 			project.gatling.verifySettings()
 			final def sourceSet = project.sourceSets.test
 			final def gatlingRequestBodiesDirectory = firstPath(sourceSet.resources.srcDirs) + "/bodies"
-			final def gatlingTestClassDirectory = sourceSet.output.classesDir
+			final def gatlingTestClassDirectory = sourceSet.output.classesDirs
 			final def gatlingClasspath = sourceSet.output + sourceSet.runtimeClasspath
 			final def scenarios = project.gatling._scenarios ?: getGatlingScenarios(sourceSet)
 


### PR DESCRIPTION
It got renamed in 5.x - see https://docs.gradle.org/current/dsl/org.gradle.api.tasks.SourceSetOutput.html#org.gradle.api.tasks.SourceSetOutput:classesDirs

Fixes an omission from #25

I have now managed to test this locally and can confirm that the plugin now works with this change applied.