### PR TITLE
BAU: Remove Gatling version from plugin code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.gradle/
 /build/
+.idea/

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
 group = 'uk.gov'
-version = "1.4-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
+version = "1.5-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 
 repositories.mavenCentral()
 dependencies {

--- a/src/main/groovy/uk/gov/gradle/plugins/GatlingPlugin.groovy
+++ b/src/main/groovy/uk/gov/gradle/plugins/GatlingPlugin.groovy
@@ -4,7 +4,6 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 class GatlingPlugin implements Plugin<Project> {
-	final String GATLING_VERSION = '2.2.3'
 
 	private String gatlingReportsDirectory
 	private Project project
@@ -13,10 +12,6 @@ class GatlingPlugin implements Plugin<Project> {
 		this.project = project
 		project.plugins.apply 'scala'
 		project.extensions.create('gatling', GatlingPluginExtension)
-		project.dependencies {
-			testCompile "io.gatling.highcharts:gatling-charts-highcharts:${GATLING_VERSION}",
-					'com.nimbusds:nimbus-jose-jwt:2.22.1'
-		}
 		gatlingReportsDirectory = "$project.buildDir.absolutePath/gatling-reports"
 		project.task('gatlingTest',
 				dependsOn:'build').doLast {


### PR DESCRIPTION
## What

Let the gradle file in the plugin and in consuming projects define the Gatling dependencies.  

## Why

This means consuming projects are able to change the Gatling version without changing the plugin.  Everything works the same as before because consuming projects are required to have Gatling dependencies to use Gatling.
