### PR TITLE
HUB-866: Publish to mavenCentral

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,13 @@
 plugins {
-  id "com.jfrog.bintray" version "1.8.4"
+    id "io.github.gradle-nexus.publish-plugin" version "1.0.0"
 }
 apply plugin: 'groovy'
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
+apply plugin: 'signing'
+apply plugin: 'io.github.gradle-nexus.publish-plugin'
 
-group = 'uk.gov'
+group = 'uk.gov.ida'
 version = "1.5-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 
 repositories.mavenCentral()
@@ -13,26 +15,66 @@ dependencies {
 	compile gradleApi()
 }
 
-bintray {
-    user = System.getenv('BINTRAY_USER')
-    key = System.getenv('BINTRAY_API_KEY')
-    publications = ['mavenJava']
-    publish = true
-    pkg {
-        repo = 'maven-test'
-        name = 'gradle-gatling-plugin'
-        userOrg = 'alphagov'
-        licenses = ['MIT']
-        vcsUrl = 'https://github.com/alphagov/gradle-gatling-plugin.git'
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
+nexusPublishing {
+    useStaging = true
+    repositories {
+        sonatype {
+            // because we registered in Sonatype after 24 Feb 2021, we provide these URIs
+            // see: https://github.com/gradle-nexus/publish-plugin/blob/master/README.md
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            username = System.getenv("SONATYPE_USERNAME")
+            password = System.getenv("SONATYPE_PASSWORD")
+        }
     }
 }
 
+signing {
+    useInMemoryPgpKeys(
+            System.getenv("MAVEN_CENTRAL_SIGNING_KEY"),
+            System.getenv("MAVEN_CENTRAL_SIGNING_KEY_PASSWORD")
+    )
+    sign publishing.publications
+}
+
 publishing {
-	publications {
-		mavenJava(MavenPublication) {
-			from components.java
-		}
-	}
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+            pom {
+                name = 'Gradle Gatling plugin'
+                packaging = 'jar'
+                description = 'Plugin for running Gatling with Gradle'
+                url = 'https://github.com/alphagov/gradle-gatling-plugin'
+                artifactId = 'gradle-gatling-plugin'
+
+                scm {
+                    url = 'https://github.com/alphagov/gradle-gatling-plugin'
+                    connection = 'scm:git:git://github.com/alphagov/gradle-gatling-plugin.git'
+                    developerConnection = 'scm:git:ssh://git@github.com:alphagov/gradle-gatling-plugin.git'
+                }
+
+                licenses {
+                    license {
+                        name = 'MIT Licence'
+                        url = 'https://github.com/alphagov/gradle-gatling-plugin/blob/master/LICENCE.txt'
+                        distribution = 'repo'
+                    }
+                }
+
+                developers {
+                    developer {
+                        name = 'GDS Developers'
+                    }
+                }
+            } // pom
+        }
+    }
 }
 
 defaultTasks 'clean', 'publishToMavenLocal'


### PR DESCRIPTION
Worth noting here the change in group. It's been historically set to
just `uk.gov`. For mavenCentral this needs to be `uk.gov/ida`.

https://github.com/alphagov/verify-infrastructure-config/pull/524